### PR TITLE
Add default handler for index page.

### DIFF
--- a/enclave.go
+++ b/enclave.go
@@ -65,6 +65,7 @@ type Config struct {
 	Debug      bool
 	FdCur      uint64
 	FdMax      uint64
+	AppURL     string
 }
 
 // NewEnclave creates and returns a new enclave with the given config.
@@ -120,6 +121,7 @@ func (e *Enclave) Start() error {
 	if inEnclave {
 		e.router.Get("/attestation", getAttestationHandler(e.certFpr))
 	}
+	e.router.Get("/", getIndexHandler(e.cfg))
 
 	// Tell Go's HTTP library to use SOCKS proxy for both HTTP and HTTPS.
 	if err := os.Setenv("HTTP_PROXY", e.cfg.SOCKSProxy); err != nil {

--- a/handlers.go
+++ b/handlers.go
@@ -1,0 +1,24 @@
+package nitriding
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func formatIndexPage(appURL string) string {
+	page := "This host runs inside an AWS Nitro Enclave.\n"
+	if appURL != "" {
+		page += fmt.Sprintf("\nIt runs the following code: %s\n"+
+			"Use the following tool to verify the enclave: "+
+			"https://github.com/brave-experiments/verify-enclave", appURL)
+	}
+	return page
+}
+
+// getIndexHandler returns an index handler that informs the visitor that this
+// host runs inside an enclave.
+func getIndexHandler(cfg *Config) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, formatIndexPage(cfg.AppURL))
+	}
+}


### PR DESCRIPTION
This patch adds a handler for the enclave's index page, which informs
the visitor that this is an enclave.  If the application URL is given,
the handler also tells the visitor what code the enclave is running and
how it can be verified.