### PR TITLE
Use pointer to cert hash for attestation, to fix ACME cert fingerprint

### DIFF
--- a/attestation.go
+++ b/attestation.go
@@ -31,7 +31,7 @@ var (
 // attestation document that contains both the nonce and the certificate hash.
 // The resulting Base64-encoded attestation document is then returned to the
 // requester.
-func getAttestationHandler(certHash [32]byte) http.HandlerFunc {
+func getAttestationHandler(certHash *[32]byte) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			http.Error(w, errMethodNotGET, http.StatusMethodNotAllowed)

--- a/attestation_test.go
+++ b/attestation_test.go
@@ -30,7 +30,7 @@ func expect(t *testing.T, resp *http.Response, statusCode int, errMsg string) {
 }
 
 func testReq(t *testing.T, req *http.Request, statusCode int, errMsg string) {
-	attestationHandler := getAttestationHandler([32]byte{})
+	attestationHandler := getAttestationHandler(&[32]byte{})
 	rec := httptest.NewRecorder()
 	attestationHandler(rec, req)
 	expect(t, rec.Result(), statusCode, errMsg)

--- a/enclave.go
+++ b/enclave.go
@@ -119,7 +119,7 @@ func (e *Enclave) Start() error {
 		return fmt.Errorf("%s: failed to create certificate: %v", errPrefix, err)
 	}
 	if inEnclave {
-		e.router.Get("/attestation", getAttestationHandler(e.certFpr))
+		e.router.Get("/attestation", getAttestationHandler(&e.certFpr))
 	}
 	e.router.Get("/", getIndexHandler(e.cfg))
 


### PR DESCRIPTION
The ACME certificate is received after server initialization, which resulted in a zeroed-out attestation "user data" fingerprint.